### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/custom_components/tesla_fleet/manifest.json
+++ b/custom_components/tesla_fleet/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "tesla-fleet-api==1.7.2"
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/tests/test_customizations.py
+++ b/tests/test_customizations.py
@@ -36,8 +36,10 @@ def test_manifest_pins_dependency_with_power_mode_methods() -> None:
 
 
 def test_manifest_has_custom_component_version() -> None:
-    # Required for HACS / custom-component loading.
-    assert _load_json("manifest.json")["version"] == "1.0.0"
+    # Required for HACS / custom-component loading; must be valid semver so the
+    # release workflow's tag-vs-version check works.
+    version = _load_json("manifest.json")["version"]
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), version
 
 
 def test_switch_source_uses_public_power_mode_api() -> None:


### PR DESCRIPTION
Bumps `custom_components/tesla_fleet/manifest.json` `version` to `1.0.1` for the first tagged release.

## ⚠️ Merge order matters
Merge this **last**, after:
1. **#12** (HA-core sync + tests/CI) — so the release contains the synced component and test suite.
2. **#3** (versioning + release workflow) — the `Release` workflow this relies on isn't on `master` until #3 lands.

Then, on `master`:
```bash
git checkout master && git pull
git tag v1.0.1
git push origin v1.0.1
```
The `Release` workflow verifies the tag matches the manifest version (`1.0.1`) and publishes a GitHub Release with auto-generated notes; HACS picks it up from the tag.

> Note: #3 and #12 also set the version to `1.0.0`; the manifest reconciles trivially (this PR just changes the one `version` line). If GitHub flags a conflict after they merge, it's only that line — I can rebase this in one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)