### PR TITLE
Read low power / keep accessory power state (v1.0.2)

### DIFF
--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -160,7 +160,7 @@ def _replace_once(text: str, old: str, new: str, what: str) -> str:
     count = text.count(old)
     if count != 1:
         raise PatchError(
-            f"switch.py: expected exactly one anchor for {what!r}, found {count}"
+            f"expected exactly one anchor for {what!r}, found {count}"
         )
     return text.replace(old, new)
 
@@ -236,9 +236,14 @@ COORD_ENDPOINTS_OLD = (
     "            response = await self.api.vehicle_data(endpoints=self.endpoints)\n"
 )
 COORD_ENDPOINTS_NEW = """\
-            response = await self.api.vehicle_data(
-                endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
-            )
+            try:
+                response = await self.api.vehicle_data(
+                    endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
+                )
+            except TeslaFleetError:
+                # The extra vehicle_data_only endpoint (power-mode state) must
+                # never take down the coordinator; fall back to the standard set.
+                response = await self.api.vehicle_data(endpoints=self.endpoints)
 """
 
 COORD_RETURN_OLD = (

--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -240,9 +240,14 @@ COORD_ENDPOINTS_NEW = """\
                 response = await self.api.vehicle_data(
                     endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
                 )
+            except (VehicleOffline, RateLimited, InvalidToken, OAuthExpired, LoginRequired):
+                # Expected errors — let the outer handlers deal with them; don't
+                # retry (avoids doubling API calls, e.g. while rate limited).
+                raise
             except TeslaFleetError:
-                # The extra vehicle_data_only endpoint (power-mode state) must
-                # never take down the coordinator; fall back to the standard set.
+                # Only an unexpected error (e.g. the vehicle_data_only endpoint
+                # being rejected) reaches here; retry without it so power-mode
+                # state is the only thing lost, not the whole coordinator.
                 response = await self.api.vehicle_data(endpoints=self.endpoints)
 """
 

--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -222,6 +222,63 @@ def patch_switch() -> None:
 
 
 # ---------------------------------------------------------------------------
+# coordinator.py
+# ---------------------------------------------------------------------------
+
+COORD_IMPORT = (
+    "from .const import DOMAIN, ENERGY_HISTORY_FIELDS, LOGGER, TeslaFleetState\n"
+)
+COORD_IMPORT_NEW = (
+    COORD_IMPORT + "from .power_mode import POWER_MODE_ENDPOINT, decode_power_modes\n"
+)
+
+COORD_ENDPOINTS_OLD = (
+    "            response = await self.api.vehicle_data(endpoints=self.endpoints)\n"
+)
+COORD_ENDPOINTS_NEW = """\
+            response = await self.api.vehicle_data(
+                endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
+            )
+"""
+
+COORD_RETURN_OLD = (
+    "                    self.update_interval = VEHICLE_WAIT\n\n        return flatten(data)\n"
+)
+COORD_RETURN_NEW = """\
+                    self.update_interval = VEHICLE_WAIT
+
+        # Low power / keep accessory power live only in the protobuf snapshot
+        # (vehicle_data_only endpoint), not the JSON. Decode and merge them in.
+        vehicle_data_pb = data.pop("vehicle_data", None)
+        result = flatten(data)
+        result.update(decode_power_modes(vehicle_data_pb))
+        return result
+"""
+
+
+def patch_coordinator() -> None:
+    """Read low power / keep accessory power from the vehicle_data protobuf.
+
+    Requests the vehicle_data_only endpoint and merges the decoded booleans
+    (from the fork-only power_mode module) into the coordinator data.
+    """
+    path = COMPONENT_DIR / "coordinator.py"
+    text = path.read_text()
+    if "from .power_mode import" in text:
+        print("coordinator.py: customizations already present")
+        return
+    text = _replace_once(text, COORD_IMPORT, COORD_IMPORT_NEW, "power_mode import")
+    text = _replace_once(
+        text, COORD_ENDPOINTS_OLD, COORD_ENDPOINTS_NEW, "vehicle_data_only endpoint"
+    )
+    text = _replace_once(
+        text, COORD_RETURN_OLD, COORD_RETURN_NEW, "power-mode decode"
+    )
+    path.write_text(text)
+    print("coordinator.py: re-applied power-mode reading")
+
+
+# ---------------------------------------------------------------------------
 # strings.json + translations/en.json
 # ---------------------------------------------------------------------------
 
@@ -327,6 +384,7 @@ def main() -> None:
         sys.exit(1)
     patch_manifest()
     patch_switch()
+    patch_coordinator()
     patch_strings()
     generate_en_json()
     print("All patches applied successfully.")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,14 @@ The only intentional differences from HA core's `tesla_fleet` are:
    components) and pins `tesla-fleet-api` to the same release HA core pins.
 3. **`strings.json` / `translations/en.json` / `icons.json`** — entries for the
    two extra switches.
-4. **`README.md` / `hacs.json`** — repo packaging, not part of core.
+4. **`coordinator.py`** — requests the `vehicle_data_only` endpoint and merges
+   the decoded low-power / keep-accessory-power state (from `power_mode.py`)
+   into the coordinator data, so the two switches show **real** state.
+5. **`power_mode.py`** — fork-only module (no core equivalent). Decodes the
+   base64 `vehicle_data` protobuf: `charge_state` field 191 = low power,
+   field 194 = keep accessory power (both undocumented in Tesla's proto, so
+   decoded from raw wire format). The upstream sync leaves it untouched.
+6. **`README.md` / `hacs.json`** — repo packaging, not part of core.
 
 When touching anything else, prefer syncing the file verbatim from HA core
 rather than editing by hand.
@@ -61,5 +68,7 @@ Upstream source lives at
 - Python style follows HA core (ruff/pylint clean; `SLF001` private-access
   lint should not be needed once the public API methods are used).
 - The domain **must** remain `tesla_fleet` — changing it breaks the override.
-- Because Tesla's API does not report power-mode state, those two switches use
-  **assumed state** (they remember the last commanded value).
+- Power-mode state is read from the protobuf snapshot (`power_mode.py`) with a
+  ~30–50s Fleet-API lag; the switches keep **assumed state** as the between-poll
+  fallback (instant feedback on your own commands, real state once it catches up
+  or when changed from the Tesla app).

--- a/custom_components/tesla_fleet/coordinator.py
+++ b/custom_components/tesla_fleet/coordinator.py
@@ -158,9 +158,14 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 response = await self.api.vehicle_data(
                     endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
                 )
+            except (VehicleOffline, RateLimited, InvalidToken, OAuthExpired, LoginRequired):
+                # Expected errors — let the outer handlers deal with them; don't
+                # retry (avoids doubling API calls, e.g. while rate limited).
+                raise
             except TeslaFleetError:
-                # The extra vehicle_data_only endpoint (power-mode state) must
-                # never take down the coordinator; fall back to the standard set.
+                # Only an unexpected error (e.g. the vehicle_data_only endpoint
+                # being rejected) reaches here; retry without it so power-mode
+                # state is the only thing lost, not the whole coordinator.
                 response = await self.api.vehicle_data(endpoints=self.endpoints)
             data = response["response"]
 

--- a/custom_components/tesla_fleet/coordinator.py
+++ b/custom_components/tesla_fleet/coordinator.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, ENERGY_HISTORY_FIELDS, LOGGER, TeslaFleetState
+from .power_mode import POWER_MODE_ENDPOINT, decode_power_modes
 
 VEHICLE_INTERVAL_SECONDS = 600
 VEHICLE_INTERVAL = timedelta(seconds=VEHICLE_INTERVAL_SECONDS)
@@ -153,7 +154,9 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self.data["state"] != TeslaFleetState.ONLINE:
                 return self.data
 
-            response = await self.api.vehicle_data(endpoints=self.endpoints)
+            response = await self.api.vehicle_data(
+                endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
+            )
             data = response["response"]
 
         except VehicleOffline:
@@ -195,7 +198,12 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # Let vehicle go to sleep now
                     self.update_interval = VEHICLE_WAIT
 
-        return flatten(data)
+        # Low power / keep accessory power live only in the protobuf snapshot
+        # (vehicle_data_only endpoint), not the JSON. Decode and merge them in.
+        vehicle_data_pb = data.pop("vehicle_data", None)
+        result = flatten(data)
+        result.update(decode_power_modes(vehicle_data_pb))
+        return result
 
 
 class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/custom_components/tesla_fleet/coordinator.py
+++ b/custom_components/tesla_fleet/coordinator.py
@@ -154,9 +154,14 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self.data["state"] != TeslaFleetState.ONLINE:
                 return self.data
 
-            response = await self.api.vehicle_data(
-                endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
-            )
+            try:
+                response = await self.api.vehicle_data(
+                    endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]
+                )
+            except TeslaFleetError:
+                # The extra vehicle_data_only endpoint (power-mode state) must
+                # never take down the coordinator; fall back to the standard set.
+                response = await self.api.vehicle_data(endpoints=self.endpoints)
             data = response["response"]
 
         except VehicleOffline:

--- a/custom_components/tesla_fleet/manifest.json
+++ b/custom_components/tesla_fleet/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "tesla-fleet-api==1.7.2"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/custom_components/tesla_fleet/power_mode.py
+++ b/custom_components/tesla_fleet/power_mode.py
@@ -1,0 +1,114 @@
+"""Read low power / keep accessory power state from the vehicle_data protobuf.
+
+These two settings are not present in the Fleet API's JSON ``vehicle_data``.
+They *are* in the base64-encoded protobuf snapshot Tesla returns when the
+``vehicle_data_only`` endpoint is requested (the same blob the mobile app
+reads). Within that ``CarServer.VehicleData`` message:
+
+* ``charge_state`` (top-level field 3) → field 191 = low power mode (bool)
+* ``charge_state`` (top-level field 3) → field 194 = keep accessory power (bool)
+
+Both fields are undocumented in Tesla's published ``vehicle.proto``, so we
+decode them straight from the protobuf wire format rather than relying on
+generated classes (which omit unknown fields). Any decode failure returns an
+empty mapping, so the switches fall back to their assumed state.
+
+This is a fork-only module — it is not part of HA core and is left untouched by
+the upstream sync.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+
+# Endpoint that makes the Fleet API include the base64 protobuf snapshot
+# alongside the usual JSON. Passed as a raw string (the library's
+# VehicleDataEndpoint enum does not define it).
+POWER_MODE_ENDPOINT = "vehicle_data_only"
+
+_CHARGE_STATE_FIELD = 3
+_LOW_POWER_MODE_FIELD = 191
+_KEEP_ACCESSORY_POWER_FIELD = 194
+
+# Coordinator data keys the two switch entities read.
+LOW_POWER_MODE_KEY = "vehicle_state_low_power_mode"
+KEEP_ACCESSORY_POWER_KEY = "vehicle_state_keep_accessory_power_on"
+
+
+def _read_varint(buf: bytes, i: int) -> tuple[int, int]:
+    shift = result = 0
+    while True:
+        byte = buf[i]
+        i += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, i
+        shift += 7
+
+
+def _skip(buf: bytes, i: int, wire: int) -> int:
+    if wire == 0:
+        _, i = _read_varint(buf, i)
+    elif wire == 1:
+        i += 8
+    elif wire == 2:
+        length, i = _read_varint(buf, i)
+        i += length
+    elif wire == 5:
+        i += 4
+    else:
+        raise ValueError(f"unsupported wire type {wire}")
+    return i
+
+
+def _message_field(buf: bytes, target: int) -> bytes | None:
+    """Return the raw bytes of a length-delimited field, or None."""
+    i, n = 0, len(buf)
+    while i < n:
+        tag, i = _read_varint(buf, i)
+        field, wire = tag >> 3, tag & 7
+        if field == target and wire == 2:
+            length, i = _read_varint(buf, i)
+            return buf[i : i + length]
+        i = _skip(buf, i, wire)
+    return None
+
+
+def _varint_field(buf: bytes, target: int) -> int | None:
+    """Return the varint value of a field, or None if absent."""
+    i, n = 0, len(buf)
+    while i < n:
+        tag, i = _read_varint(buf, i)
+        field, wire = tag >> 3, tag & 7
+        if field == target and wire == 0:
+            value, _ = _read_varint(buf, i)
+            return value
+        i = _skip(buf, i, wire)
+    return None
+
+
+def decode_power_modes(vehicle_data_b64: str | None) -> dict[str, bool]:
+    """Extract the two power-mode booleans from the vehicle_data protobuf.
+
+    Returns an empty mapping if the blob is missing or cannot be decoded, so
+    callers keep whatever state they already have.
+    """
+    if not vehicle_data_b64:
+        return {}
+    try:
+        blob = base64.b64decode(vehicle_data_b64)
+        charge_state = _message_field(blob, _CHARGE_STATE_FIELD)
+        if charge_state is None:
+            return {}
+        low_power = _varint_field(charge_state, _LOW_POWER_MODE_FIELD)
+        keep_accessory = _varint_field(charge_state, _KEEP_ACCESSORY_POWER_FIELD)
+    except (ValueError, IndexError, binascii.Error):
+        return {}
+
+    result: dict[str, bool] = {}
+    if low_power is not None:
+        result[LOW_POWER_MODE_KEY] = bool(low_power)
+    if keep_accessory is not None:
+        result[KEEP_ACCESSORY_POWER_KEY] = bool(keep_accessory)
+    return result

--- a/tests/test_apply_patches.py
+++ b/tests/test_apply_patches.py
@@ -176,6 +176,44 @@ def test_switch_patch_reinjects_customizations(tmp_path, monkeypatch) -> None:
     assert (comp / "switch.py").read_text() == result
 
 
+CORE_COORDINATOR = (
+    "from .const import DOMAIN, ENERGY_HISTORY_FIELDS, LOGGER, TeslaFleetState\n"
+    "\n\n"
+    "class TeslaFleetVehicleDataCoordinator:\n"
+    "    async def _async_update_data(self):\n"
+    "        try:\n"
+    "            response = await self.api.vehicle_data(endpoints=self.endpoints)\n"
+    '            data = response["response"]\n'
+    "        except Exception:\n"
+    "            pass\n"
+    "        if a:\n"
+    "            if b:\n"
+    "                if c:\n"
+    "                    self.update_interval = VEHICLE_WAIT\n"
+    "\n"
+    "        return flatten(data)\n"
+)
+
+
+def test_coordinator_patch_adds_power_mode_reading(tmp_path, monkeypatch) -> None:
+    comp = tmp_path / "tesla_fleet"
+    comp.mkdir()
+    (comp / "coordinator.py").write_text(CORE_COORDINATOR)
+    monkeypatch.setattr(ap, "COMPONENT_DIR", comp)
+
+    ap.patch_coordinator()
+    result = (comp / "coordinator.py").read_text()
+
+    assert "from .power_mode import POWER_MODE_ENDPOINT, decode_power_modes" in result
+    assert "endpoints=[*self.endpoints, POWER_MODE_ENDPOINT]" in result
+    assert 'data.pop("vehicle_data", None)' in result
+    assert "decode_power_modes(vehicle_data_pb)" in result
+
+    # Re-running is a no-op.
+    ap.patch_coordinator()
+    assert (comp / "coordinator.py").read_text() == result
+
+
 def test_switch_patch_fails_loudly_on_missing_anchor(tmp_path, monkeypatch) -> None:
     comp = tmp_path / "tesla_fleet"
     comp.mkdir()

--- a/tests/test_power_mode.py
+++ b/tests/test_power_mode.py
@@ -88,3 +88,33 @@ def test_bad_input_returns_empty() -> None:
     assert pm.decode_power_modes("") == {}
     assert pm.decode_power_modes("not valid base64 @@@") == {}
     assert pm.decode_power_modes(base64.b64encode(b"\xff\xff\xff").decode()) == {}
+
+
+def test_malformed_protobuf_is_safe() -> None:
+    # Length-delimited field claiming more bytes than present (truncated).
+    truncated = _varint((3 << 3) | 2) + _varint(50) + b"\x08"
+    assert pm.decode_power_modes(base64.b64encode(truncated).decode()) == {}
+    # Unsupported wire type (group start = 3) inside charge_state.
+    grouped = _submessage(3, _varint((5 << 3) | 3))
+    assert pm.decode_power_modes(base64.b64encode(grouped).decode()) == {}
+    # Truncated varint (continuation bit set, no following byte).
+    bad_varint = _submessage(3, _varint((191 << 3) | 0) + b"\x80")
+    assert pm.decode_power_modes(base64.b64encode(bad_varint).decode()) == {}
+
+
+def test_power_field_with_wrong_wire_type_is_ignored() -> None:
+    # field 191 encoded as length-delimited (wire 2) instead of a varint.
+    blob = _submessage(3, _submessage(191, b"\x00"))
+    assert pm.decode_power_modes(base64.b64encode(blob).decode()) == {}
+
+
+def test_coordinator_merge_contract() -> None:
+    # Mirrors what coordinator._async_update_data does: pop the protobuf, decode
+    # it, and merge the booleans into the (flattened) result dict.
+    data = {"charge_state": {"battery_level": 50}, "vehicle_data": _make(low=1, keep=0)}
+    raw = data.pop("vehicle_data", None)
+    merged: dict = {}
+    merged.update(pm.decode_power_modes(raw))
+    assert "vehicle_data" not in data
+    assert merged["vehicle_state_low_power_mode"] is True
+    assert merged["vehicle_state_keep_accessory_power_on"] is False

--- a/tests/test_power_mode.py
+++ b/tests/test_power_mode.py
@@ -1,0 +1,90 @@
+"""Tests for the vehicle_data protobuf power-mode decoder.
+
+The module has no Home Assistant dependency, so it is imported by path and the
+protobuf inputs are built synthetically (no real vehicle data / VIN needed).
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+from pathlib import Path
+
+MODULE = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "tesla_fleet"
+    / "power_mode.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("power_mode", MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pm = _load()
+
+
+def _varint(n: int) -> bytes:
+    out = b""
+    while n > 0x7F:
+        out += bytes([(n & 0x7F) | 0x80])
+        n >>= 7
+    return out + bytes([n])
+
+
+def _field(num: int, value: int) -> bytes:
+    """A varint field."""
+    return _varint(num << 3) + _varint(value)
+
+
+def _submessage(num: int, payload: bytes) -> bytes:
+    return _varint((num << 3) | 2) + _varint(len(payload)) + payload
+
+
+def _make(low=None, keep=None, include_battery=True, charge_field=3) -> str:
+    inner = b""
+    if include_battery:
+        inner += _field(114, 47)  # battery_level — must be ignored
+    if low is not None:
+        inner += _field(191, low)
+    if keep is not None:
+        inner += _field(194, keep)
+    blob = _submessage(charge_field, inner)
+    return base64.b64encode(blob).decode()
+
+
+def test_decodes_both_flags() -> None:
+    assert pm.decode_power_modes(_make(low=1, keep=0)) == {
+        "vehicle_state_low_power_mode": True,
+        "vehicle_state_keep_accessory_power_on": False,
+    }
+    assert pm.decode_power_modes(_make(low=0, keep=1)) == {
+        "vehicle_state_low_power_mode": False,
+        "vehicle_state_keep_accessory_power_on": True,
+    }
+
+
+def test_only_present_fields_are_returned() -> None:
+    assert pm.decode_power_modes(_make(low=1)) == {
+        "vehicle_state_low_power_mode": True
+    }
+    # charge_state present but neither power field set
+    assert pm.decode_power_modes(_make()) == {}
+
+
+def test_ignores_other_fields_and_missing_charge_state() -> None:
+    # battery_level (114) must not be mistaken for a power flag
+    assert pm.decode_power_modes(_make(include_battery=True)) == {}
+    # top-level message without charge_state (field 3)
+    assert pm.decode_power_modes(_make(low=1, charge_field=9)) == {}
+
+
+def test_bad_input_returns_empty() -> None:
+    assert pm.decode_power_modes(None) == {}
+    assert pm.decode_power_modes("") == {}
+    assert pm.decode_power_modes("not valid base64 @@@") == {}
+    assert pm.decode_power_modes(base64.b64encode(b"\xff\xff\xff").decode()) == {}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -83,3 +83,31 @@ def test_library_methods_accept_on_kwarg(method: str) -> None:
     # signed commands that take a single ``on`` argument.
     params = inspect.signature(getattr(Commands, method)).parameters
     assert list(params) == ["self", "on"]
+
+
+@pytest.mark.parametrize("key", CUSTOM_SWITCHES)
+def test_switch_reflects_decoded_coordinator_state(key: str) -> None:
+    # The coordinator merges the decoded protobuf booleans under the switch
+    # keys; the entity must surface them as is_on (and keep the last value as
+    # assumed state when the key is momentarily absent).
+    from types import SimpleNamespace
+
+    entity = switch.TeslaFleetVehicleSwitchEntity.__new__(
+        switch.TeslaFleetVehicleSwitchEntity
+    )
+    entity.entity_description = _description(key)
+    entity.key = key
+    entity._attr_is_on = None
+    entity.coordinator = SimpleNamespace(data={key: True})
+
+    entity._async_update_attrs()
+    assert entity._attr_is_on is True
+
+    entity.coordinator.data[key] = False
+    entity._async_update_attrs()
+    assert entity._attr_is_on is False
+
+    # Key absent this cycle -> assumed_state keeps the last known value.
+    entity.coordinator.data.clear()
+    entity._async_update_attrs()
+    assert entity._attr_is_on is False

--- a/tools/decode_pb.py
+++ b/tools/decode_pb.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Decode a base64-encoded protobuf blob into a flat field-number tree.
+
+For decoding the base64 protobuf the Tesla app uses (captured via MITM proxy).
+Feed it the ON capture and the OFF capture, then diff the two outputs to find
+the field that holds the setting.
+
+USAGE:
+    python3 tools/decode_pb.py <file-with-base64>      # or pipe base64 on stdin
+    python3 tools/decode_pb.py app_on.b64  > on.txt
+    python3 tools/decode_pb.py app_off.b64 > off.txt
+    diff on.txt off.txt
+
+Input may contain whitespace/newlines and may be standard or URL-safe base64.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import sys
+
+
+def _b64decode(text: str) -> bytes:
+    raw = "".join(text.split())  # strip all whitespace/newlines
+    raw += "=" * (-len(raw) % 4)  # fix padding
+    for decoder in (base64.b64decode, base64.urlsafe_b64decode):
+        try:
+            return decoder(raw)
+        except (binascii.Error, ValueError):
+            continue
+    raise SystemExit("input is not valid base64")
+
+
+def _read_varint(buf: bytes, i: int) -> tuple[int, int]:
+    shift = result = 0
+    while True:
+        b = buf[i]
+        i += 1
+        result |= (b & 0x7F) << shift
+        if not b & 0x80:
+            return result, i
+        shift += 7
+
+
+def _looks_like_message(buf: bytes) -> bool:
+    try:
+        _decode(buf)
+        return True
+    except Exception:
+        return False
+
+
+def _decode(buf: bytes, prefix: str = "") -> dict[str, object]:
+    out: dict[str, object] = {}
+    i, n = 0, len(buf)
+    while i < n:
+        tag, i = _read_varint(buf, i)
+        field, wire = tag >> 3, tag & 7
+        path = f"{prefix}{field}"
+        if wire == 0:
+            out[path], i = _read_varint(buf, i)
+        elif wire == 1:
+            out[path] = int.from_bytes(buf[i : i + 8], "little")
+            i += 8
+        elif wire == 2:
+            ln, i = _read_varint(buf, i)
+            sub = buf[i : i + ln]
+            i += ln
+            if sub and _looks_like_message(sub):
+                for k, v in _decode(sub).items():
+                    out[f"{path}.{k}"] = v
+            else:
+                try:
+                    text = sub.decode("utf-8")
+                    out[path] = text if text.isprintable() else sub.hex()
+                except UnicodeDecodeError:
+                    out[path] = sub.hex()
+        elif wire == 5:
+            out[path] = int.from_bytes(buf[i : i + 4], "little")
+            i += 4
+        else:
+            raise ValueError(f"bad wire type {wire}")
+    return out
+
+
+def main() -> int:
+    text = open(sys.argv[1]).read() if len(sys.argv) > 1 else sys.stdin.read()
+    fields = _decode(_b64decode(text))
+    for path in sorted(fields, key=lambda p: [int(x) for x in p.split(".")]):
+        print(f"{path} = {fields[path]!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/probe_cached_data.py
+++ b/tools/probe_cached_data.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Probe the protobuf `cached_data` blob from Tesla Fleet /api/1/products.
+
+The Tesla Fleet integration discards `cached_data` (a protobuf-encoded snapshot
+of vehicle state). Low power mode / keep accessory power are not in the JSON
+vehicle_data, so this tool decodes `cached_data` to see whether their state is
+in there.
+
+USAGE (run it yourself so your token never leaves your shell):
+
+    TESLA_TOKEN=<fleet_api_access_token> \
+    TESLA_VIN=<your_vin> \
+    TESLA_REGION=na \
+    python3 tools/probe_cached_data.py > before.txt
+
+Then, in the Tesla app, toggle ONE setting (e.g. Controls > Charging > Low
+Power Mode), wait ~30 s, and run it again into `after.txt`. Diff them:
+
+    diff before.txt after.txt
+
+The line(s) that change point at the protobuf field that holds the setting —
+paste that diff and I'll wire the switch to read it. Repeat for Keep Accessory
+Power.
+
+No external dependencies; pure standard library. Region is `na` or `eu`.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+REGION_HOST = {
+    "na": "fleet-api.prd.na.vn.cloud.tesla.com",
+    "eu": "fleet-api.prd.eu.vn.cloud.tesla.com",
+}
+
+
+def _read_varint(buf: bytes, i: int) -> tuple[int, int]:
+    shift = result = 0
+    while True:
+        b = buf[i]
+        i += 1
+        result |= (b & 0x7F) << shift
+        if not b & 0x80:
+            return result, i
+        shift += 7
+
+
+def _looks_like_message(buf: bytes) -> bool:
+    """Heuristic: does `buf` parse cleanly as a protobuf message to its end?"""
+    try:
+        _decode(buf)
+        return True
+    except Exception:
+        return False
+
+
+def _decode(buf: bytes, prefix: str = "") -> dict[str, object]:
+    out: dict[str, object] = {}
+    i, n = 0, len(buf)
+    while i < n:
+        tag, i = _read_varint(buf, i)
+        field, wire = tag >> 3, tag & 7
+        path = f"{prefix}{field}"
+        if wire == 0:  # varint (bool / int / enum)
+            val, i = _read_varint(buf, i)
+            out[path] = val
+        elif wire == 1:  # 64-bit
+            out[path] = int.from_bytes(buf[i : i + 8], "little")
+            i += 8
+        elif wire == 2:  # length-delimited: nested message, string, or bytes
+            ln, i = _read_varint(buf, i)
+            sub = buf[i : i + ln]
+            i += ln
+            if sub and _looks_like_message(sub):
+                for k, v in _decode(sub).items():
+                    out[f"{path}.{k}"] = v
+            else:
+                try:
+                    text = sub.decode("utf-8")
+                    out[path] = text if text.isprintable() else sub.hex()
+                except UnicodeDecodeError:
+                    out[path] = sub.hex()
+        elif wire == 5:  # 32-bit
+            out[path] = int.from_bytes(buf[i : i + 4], "little")
+            i += 4
+        else:
+            raise ValueError(f"bad wire type {wire}")
+    return out
+
+
+def main() -> int:
+    token = os.environ.get("TESLA_TOKEN")
+    vin = os.environ.get("TESLA_VIN")
+    region = os.environ.get("TESLA_REGION", "").lower()
+    if not token:
+        print("Set TESLA_TOKEN (and TESLA_VIN; omit VIN to list vehicles).", file=sys.stderr)
+        return 2
+
+    # Region defaults to trying na then eu so you don't have to know it.
+    candidates = [region] if region in REGION_HOST else ["na", "eu"]
+    products = None
+    for cand in candidates:
+        req = urllib.request.Request(
+            f"https://{REGION_HOST[cand]}/api/1/products",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                products = json.loads(resp.read().decode())["response"]
+            print(f"(region: {cand})", file=sys.stderr)
+            break
+        except urllib.error.HTTPError as err:
+            if err.code in (401, 403):
+                print(f"HTTP {err.code}: token invalid/expired.", file=sys.stderr)
+                return 1
+            continue  # wrong region → try the next one
+    if products is None:
+        print("Could not fetch products from either region.", file=sys.stderr)
+        return 1
+
+    if not vin:
+        # No VIN given: list what's available so you can pick one.
+        print("Products (set TESLA_VIN to one of these):", file=sys.stderr)
+        for p in products:
+            if "vin" in p:
+                has = "cached_data" if p.get("cached_data") else "NO cached_data"
+                print(f"  {p['vin']}  ({has})", file=sys.stderr)
+        return 0
+
+    product = next((p for p in products if p.get("vin") == vin), None)
+    if product is None:
+        print(f"VIN {vin} not found in products.", file=sys.stderr)
+        return 1
+    raw = product.get("cached_data")
+    if not raw:
+        print("No cached_data on this product.", file=sys.stderr)
+        return 1
+
+    blob = base64.b64decode(raw)
+    fields = _decode(blob)
+    # Sort by path for a stable, diff-friendly dump.
+    for path in sorted(fields, key=lambda p: [int(x) for x in p.split(".")]):
+        print(f"{path} = {fields[path]!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Makes the two power-mode switches show **real state** — including changes made from the Tesla app — instead of assumed-only.

## The discovery
These settings are **not** in the Fleet API JSON. But the app (via MITM proxy) reads them from the base64 protobuf `vehicle_data` field, which the **Fleet API also returns when you add the `vehicle_data_only` endpoint** (the "slightly different args" difference). Verified against a live vehicle with A/B/A toggle-diffs:

| setting | protobuf field | ON | OFF |
|---------|----------------|----|----|
| Low Power Mode | `charge_state` #191 | `1` | `0` |
| Keep Accessory Power | `charge_state` #194 | `1` | `0` |

Both are **undocumented** in Tesla's published `vehicle.proto`, so they're decoded from raw protobuf wire format (the tested decoder matched every live capture: accessory-on → `keep=True`, low-power-on → `low=True`, both-off → both `False`).

## Changes
- **`power_mode.py`** (new, fork-only — untouched by sync): decodes `charge_state.191`/`.194` → bools; returns `{}` on any malformed input so switches fall back to assumed state.
- **`coordinator.py`**: requests `vehicle_data_only`, decodes the protobuf, merges the two booleans into coordinator data under the existing switch keys. `assumed_state` stays as the between-poll fallback (Fleet API lags ~30–50s behind the app, so you still get instant feedback on your own toggles).
- **`apply_patches.py`**: re-applies the `coordinator.py` edits on each upstream sync (verified: a fresh core checkout run through it reproduces these edits byte-for-byte).
- **Tests**: synthetic-protobuf decoder tests + `patch_coordinator` reproducibility/idempotency. **30 passed**, ruff clean.
- **`tools/`**: `probe_cached_data.py` + `decode_pb.py` — the utilities used to find the fields (dev-only, not shipped in the HACS package).
- **`AGENTS.md`** updated; **manifest → 1.0.2**.

## Notes
- No `switch.py` change needed — the switch keys already map; the coordinator just supplies real values now.
- Non-signing vehicles are unaffected (the switches are already gated off for them).
- Low Power Mode field wiring is included and A/B/A-confirmed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)