### PR TITLE
Log per-vehicle command_signing at debug level (#17)

### DIFF
--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -8,6 +8,8 @@ that make this a custom component:
 * ``manifest.json`` — the ``version`` field custom components require.
 * ``switch.py`` — the two extra vehicle switches (low power mode / keep
   accessory power) sent via the public ``tesla-fleet-api`` power-mode methods.
+* ``__init__.py`` — a debug log of the raw per-vehicle ``command_signing``
+  value, so a user whose power-mode switches are missing can diagnose why.
 * ``strings.json`` — the entity names for those two switches.
 * ``translations/en.json`` — regenerated from ``strings.json`` with all
   ``[%key:...%]`` references resolved (HA core ships this via build tooling;
@@ -226,6 +228,44 @@ def patch_switch() -> None:
 
 
 # ---------------------------------------------------------------------------
+# __init__.py
+# ---------------------------------------------------------------------------
+
+INIT_SIGNING_ANCHOR = '            signing = product["command_signing"] == "required"\n'
+INIT_SIGNING_NEW = INIT_SIGNING_ANCHOR + (
+    "            # Fork-only diagnostic (issue #17): the low power / keep accessory\n"
+    "            # power switches are only offered when Tesla reports command signing\n"
+    "            # is required. Log the raw value so a user whose switches are missing\n"
+    "            # can confirm what Tesla returns for their VIN.\n"
+    "            LOGGER.debug(\n"
+    '                "Vehicle %s command_signing=%r -> power-mode switches %s",\n'
+    "                vin,\n"
+    '                product.get("command_signing"),\n'
+    '                "offered" if signing else "hidden",\n'
+    "            )\n"
+)
+
+
+def patch_init() -> None:
+    """Re-add the per-vehicle command_signing debug log.
+
+    Upstream computes ``signing`` from ``command_signing`` but never logs the
+    raw value, so a user whose power-mode switches are missing cannot tell what
+    Tesla returned for their VIN. This adds a debug line right after the check.
+    """
+    path = COMPONENT_DIR / "__init__.py"
+    text = path.read_text()
+    if "command_signing=%r" in text:
+        print("__init__.py: customizations already present")
+        return
+    text = _replace_once(
+        text, INIT_SIGNING_ANCHOR, INIT_SIGNING_NEW, "command_signing debug log"
+    )
+    path.write_text(text)
+    print("__init__.py: re-applied command_signing debug log")
+
+
+# ---------------------------------------------------------------------------
 # coordinator.py
 # ---------------------------------------------------------------------------
 
@@ -423,6 +463,7 @@ def main() -> None:
         sys.exit(1)
     patch_manifest()
     patch_switch()
+    patch_init()
     patch_coordinator()
     patch_strings()
     generate_en_json()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,12 @@ The only intentional differences from HA core's `tesla_fleet` are:
    base64 `vehicle_data` protobuf: `charge_state` field 191 = low power,
    field 194 = keep accessory power (both undocumented in Tesla's proto, so
    decoded from raw wire format). The upstream sync leaves it untouched.
-6. **`README.md` / `hacs.json`** — repo packaging, not part of core.
+6. **`__init__.py`** — a single `LOGGER.debug` line after the `command_signing`
+   check that logs the raw per-vehicle value, so a user whose power-mode
+   switches are missing can diagnose why (the switches only appear when
+   `command_signing == "required"`). Re-applied by `patch_init` in
+   `apply_patches.py`.
+7. **`README.md` / `hacs.json`** — repo packaging, not part of core.
 
 When touching anything else, prefer syncing the file verbatim from HA core
 rather than editing by hand.

--- a/custom_components/tesla_fleet/__init__.py
+++ b/custom_components/tesla_fleet/__init__.py
@@ -166,6 +166,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             product.pop("cached_data", None)
             vin = product["vin"]
             signing = product["command_signing"] == "required"
+            # Fork-only diagnostic (issue #17): the low power / keep accessory
+            # power switches are only offered when Tesla reports command signing
+            # is required. Log the raw value so a user whose switches are missing
+            # can confirm what Tesla returns for their VIN.
+            LOGGER.debug(
+                "Vehicle %s command_signing=%r -> power-mode switches %s",
+                vin,
+                product.get("command_signing"),
+                "offered" if signing else "hidden",
+            )
             api_vehicle: VehicleFleet
             if signing:
                 if not tesla.private_key:

--- a/custom_components/tesla_fleet/manifest.json
+++ b/custom_components/tesla_fleet/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "tesla-fleet-api==1.7.2"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/tests/test_apply_patches.py
+++ b/tests/test_apply_patches.py
@@ -243,6 +243,49 @@ def test_coordinator_patch_adds_power_mode_reading(tmp_path, monkeypatch) -> Non
     assert (comp / "coordinator.py").read_text() == result
 
 
+CORE_INIT = (
+    "def async_setup_entry(hass, entry, products, scopes):\n"
+    "    for product in products:\n"
+    '        if "vin" in product and Scope.VEHICLE_DEVICE_DATA in scopes:\n'
+    '            vin = product["vin"]\n'
+    '            signing = product["command_signing"] == "required"\n'
+    "            api_vehicle = None\n"
+)
+
+
+def test_init_patch_adds_command_signing_log(tmp_path, monkeypatch) -> None:
+    comp = tmp_path / "tesla_fleet"
+    comp.mkdir()
+    (comp / "__init__.py").write_text(CORE_INIT)
+    monkeypatch.setattr(ap, "COMPONENT_DIR", comp)
+
+    ap.patch_init()
+    result = (comp / "__init__.py").read_text()
+
+    assert "LOGGER.debug(" in result
+    assert "command_signing=%r" in result
+    assert '"offered" if signing else "hidden"' in result
+    # The signing check and the log line must both be present and in order.
+    assert result.index('signing = product["command_signing"]') < result.index(
+        "LOGGER.debug("
+    )
+    compile(result, "__init__.py", "exec")
+
+    # Re-running is a no-op.
+    ap.patch_init()
+    assert (comp / "__init__.py").read_text() == result
+
+
+def test_init_patch_fails_loudly_on_missing_anchor(tmp_path, monkeypatch) -> None:
+    comp = tmp_path / "tesla_fleet"
+    comp.mkdir()
+    (comp / "__init__.py").write_text("# an upstream file with no known anchors\n")
+    monkeypatch.setattr(ap, "COMPONENT_DIR", comp)
+
+    with pytest.raises(ap.PatchError):
+        ap.patch_init()
+
+
 def test_switch_patch_fails_loudly_on_missing_anchor(tmp_path, monkeypatch) -> None:
     comp = tmp_path / "tesla_fleet"
     comp.mkdir()

--- a/tests/test_customizations.py
+++ b/tests/test_customizations.py
@@ -54,6 +54,15 @@ def test_switch_source_uses_public_power_mode_api() -> None:
     assert "protobuf" not in src
 
 
+def test_init_logs_per_vehicle_command_signing() -> None:
+    # Fork-only diagnostic (issue #17): the raw command_signing value is logged
+    # at debug so a user whose power-mode switches are missing can see what
+    # Tesla returned for their VIN. Must survive an upstream sync.
+    src = (COMPONENT / "__init__.py").read_text()
+    assert "command_signing=%r" in src
+    assert "LOGGER.debug(" in src
+
+
 def test_strings_have_custom_switch_names() -> None:
     switch = _load_json("strings.json")["entity"]["switch"]
     for key, name in CUSTOM_SWITCH_NAMES.items():


### PR DESCRIPTION
Closes #17.

## Problem

The Low Power Mode and Keep Accessory Power switches only appear for
vehicles where Tesla reports `command_signing == "required"`. When they're
missing there's no error, and the library only logs a summary line for the
`/api/1/products` call — so a user can't see what Tesla actually returned
for their VIN and can't tell whether it's expected (`not_required`) or a
fork misinterpretation.

## Change

Add a single `LOGGER.debug` line after the signing check in `__init__.py`:

```
Vehicle <VIN> command_signing='not_required' -> power-mode switches hidden
```

It logs the raw `command_signing` value (via `.get`, so an unexpected
absence shows as `None` rather than raising) and whether the power-mode
switches will be offered.

`__init__.py` is otherwise a verbatim copy of HA core, so `patch_init` in
`apply_patches.py` re-applies the log after every upstream sync — with the
same fail-loud-on-missing-anchor / idempotent behaviour as the other
patches, and documented in the golden-rule list in AGENTS.md.

## Tests

- `test_apply_patches.py` — patch re-injects the log on a pristine core
  file, is idempotent, and fails loudly if the anchor is gone.
- `test_customizations.py` — the shipped `__init__.py` still carries the
  log (guards against a sync dropping it).

`ruff` clean; the two HA-free test modules pass (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)