### PR TITLE
Treat command_signing="allowed" as signing-capable (fixes hidden Low …

### DIFF
--- a/custom_components/tesla_fleet/__init__.py
+++ b/custom_components/tesla_fleet/__init__.py
@@ -165,7 +165,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             # Remove the protobuff 'cached_data' that we do not use to save memory
             product.pop("cached_data", None)
             vin = product["vin"]
-            signing = product["command_signing"] == "required"
+            signing = product["command_signing"] in ("required", "allowed")
             api_vehicle: VehicleFleet
             if signing:
                 if not tesla.private_key:


### PR DESCRIPTION
Treat command_signing="allowed" as signing-capable (fixes hidden Low Power / Keep Accessory Power switches) Relates to #17 — using the `tesla_fleet_api: debug` approach discussed there, the value turned out to be `command_signing: "allowed"`, which this PR handles.

## Problem

On my 2025 Model 3 the **Low Power Mode** and **Keep Accessory Power** switches never appeared — no error, no auth issue.

Enabling `tesla_fleet_api: debug` and reading the `/api/1/products` response shows Tesla returns a third value for `command_signing`:
    'command_signing': 'allowed'

Not `required`, not `not_required`. The current check in `__init__.py`:
    signing = product["command_signing"] == "required"


evaluates to False for `allowed` vehicles, so `vehicle.signing` is False and the signed-only switches (gated by `signing_required=True` in `switch.py`) are never created.

Since `allowed` means the vehicle **does support** the Vehicle Command Protocol (signing is permitted, just not mandatory), these switches should be offered too.

## Change

```diff
- signing = product["command_signing"] == "required"
+ signing = product["command_signing"] in ("required", "allowed")
```

## Tested

On HA 2026.7.2 with this fork, 2025 Model 3 (`command_signing="allowed"`):

- Both switches now appear.
- Integration loads cleanly (no signing/command errors).
- Toggled **Keep Accessory Power** on→off — the signed command succeeded, so signed transport works for `allowed` vehicles when the virtual key is paired.

## Note

`signing` also selects `createSigned()` vs `createFleet()` for *all* commands on the vehicle, so this routes `allowed` vehicles through the signed path (which needs the virtual key paired). Happy to adjust if you'd prefer to decouple "show signed-only switches" from "use signed transport".