### PR TITLE
Release 1.0.4: per-vehicle command_signing debug log + treat "allowed" as signing-capable

### DIFF
--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -8,8 +8,10 @@ that make this a custom component:
 * ``manifest.json`` — the ``version`` field custom components require.
 * ``switch.py`` — the two extra vehicle switches (low power mode / keep
   accessory power) sent via the public ``tesla-fleet-api`` power-mode methods.
-* ``__init__.py`` — a debug log of the raw per-vehicle ``command_signing``
-  value, so a user whose power-mode switches are missing can diagnose why.
+* ``__init__.py`` — treat ``command_signing == "allowed"`` as signing-capable
+  (not just ``"required"``) so the switches appear on those vehicles, plus a
+  debug log of the raw per-vehicle ``command_signing`` value so a user whose
+  power-mode switches are missing can diagnose why.
 * ``strings.json`` — the entity names for those two switches.
 * ``translations/en.json`` — regenerated from ``strings.json`` with all
   ``[%key:...%]`` references resolved (HA core ships this via build tooling;
@@ -232,11 +234,17 @@ def patch_switch() -> None:
 # ---------------------------------------------------------------------------
 
 INIT_SIGNING_ANCHOR = '            signing = product["command_signing"] == "required"\n'
-INIT_SIGNING_NEW = INIT_SIGNING_ANCHOR + (
-    "            # Fork-only diagnostic (issue #17): the low power / keep accessory\n"
-    "            # power switches are only offered when Tesla reports command signing\n"
-    "            # is required. Log the raw value so a user whose switches are missing\n"
-    "            # can confirm what Tesla returns for their VIN.\n"
+INIT_SIGNING_NEW = (
+    '            signing = product["command_signing"] in ("required", "allowed")\n'
+    "            # Fork-only diagnostic (issues #17 / #19): the low power / keep\n"
+    "            # accessory power switches are only offered when the vehicle is\n"
+    "            # command-signing capable. Tesla returns \"required\", \"allowed\", or\n"
+    "            # \"not_required\"; both \"required\" and \"allowed\" mean the vehicle\n"
+    "            # supports the Vehicle Command Protocol, so treat both as signing\n"
+    "            # (core only checks \"required\", which hides the switches on\n"
+    "            # \"allowed\" vehicles such as the 2025 Model 3). Log the raw value so\n"
+    "            # a user whose switches are missing can confirm what Tesla returns\n"
+    "            # for their VIN.\n"
     "            LOGGER.debug(\n"
     '                "Vehicle %s command_signing=%r -> power-mode switches %s",\n'
     "                vin,\n"
@@ -247,11 +255,14 @@ INIT_SIGNING_NEW = INIT_SIGNING_ANCHOR + (
 
 
 def patch_init() -> None:
-    """Re-add the per-vehicle command_signing debug log.
+    """Widen the ``signing`` check and add a per-vehicle debug log.
 
-    Upstream computes ``signing`` from ``command_signing`` but never logs the
-    raw value, so a user whose power-mode switches are missing cannot tell what
-    Tesla returned for their VIN. This adds a debug line right after the check.
+    Upstream computes ``signing`` as ``command_signing == "required"`` and never
+    logs the raw value. Tesla also returns ``"allowed"`` (e.g. the 2025 Model 3),
+    which likewise means the vehicle supports the Vehicle Command Protocol, so we
+    widen the check to ``in ("required", "allowed")`` (issue #19). We also add a
+    debug line right after the check so a user whose power-mode switches are
+    missing can tell what Tesla returned for their VIN (issue #17).
     """
     path = COMPONENT_DIR / "__init__.py"
     text = path.read_text()

--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -8,6 +8,8 @@ that make this a custom component:
 * ``manifest.json`` — the ``version`` field custom components require.
 * ``switch.py`` — the two extra vehicle switches (low power mode / keep
   accessory power) sent via the public ``tesla-fleet-api`` power-mode methods.
+* ``__init__.py`` — a debug log of the raw per-vehicle ``command_signing``
+  value, so a user whose power-mode switches are missing can diagnose why.
 * ``strings.json`` — the entity names for those two switches.
 * ``translations/en.json`` — regenerated from ``strings.json`` with all
   ``[%key:...%]`` references resolved (HA core ships this via build tooling;
@@ -226,6 +228,44 @@ def patch_switch() -> None:
 
 
 # ---------------------------------------------------------------------------
+# __init__.py
+# ---------------------------------------------------------------------------
+
+INIT_SIGNING_ANCHOR = '            signing = product["command_signing"] == "required"\n'
+INIT_SIGNING_NEW = INIT_SIGNING_ANCHOR + (
+    "            # Fork-only diagnostic (issue #17): the low power / keep accessory\n"
+    "            # power switches are only offered when Tesla reports command signing\n"
+    "            # is required. Log the raw value so a user whose switches are missing\n"
+    "            # can confirm what Tesla returns for their VIN.\n"
+    "            LOGGER.debug(\n"
+    '                "Vehicle %s command_signing=%r -> power-mode switches %s",\n'
+    "                vin,\n"
+    '                product.get("command_signing"),\n'
+    '                "offered" if signing else "hidden",\n'
+    "            )\n"
+)
+
+
+def patch_init() -> None:
+    """Re-add the per-vehicle command_signing debug log.
+
+    Upstream computes ``signing`` from ``command_signing`` but never logs the
+    raw value, so a user whose power-mode switches are missing cannot tell what
+    Tesla returned for their VIN. This adds a debug line right after the check.
+    """
+    path = COMPONENT_DIR / "__init__.py"
+    text = path.read_text()
+    if "command_signing=%r" in text:
+        print("__init__.py: customizations already present")
+        return
+    text = _replace_once(
+        text, INIT_SIGNING_ANCHOR, INIT_SIGNING_NEW, "command_signing debug log"
+    )
+    path.write_text(text)
+    print("__init__.py: re-applied command_signing debug log")
+
+
+# ---------------------------------------------------------------------------
 # coordinator.py
 # ---------------------------------------------------------------------------
 
@@ -423,6 +463,7 @@ def main() -> None:
         sys.exit(1)
     patch_manifest()
     patch_switch()
+    patch_init()
     patch_coordinator()
     patch_strings()
     generate_en_json()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,12 @@ The only intentional differences from HA core's `tesla_fleet` are:
    base64 `vehicle_data` protobuf: `charge_state` field 191 = low power,
    field 194 = keep accessory power (both undocumented in Tesla's proto, so
    decoded from raw wire format). The upstream sync leaves it untouched.
-6. **`README.md` / `hacs.json`** — repo packaging, not part of core.
+6. **`__init__.py`** — a single `LOGGER.debug` line after the `command_signing`
+   check that logs the raw per-vehicle value, so a user whose power-mode
+   switches are missing can diagnose why (the switches only appear when
+   `command_signing == "required"`). Re-applied by `patch_init` in
+   `apply_patches.py`.
+7. **`README.md` / `hacs.json`** — repo packaging, not part of core.
 
 When touching anything else, prefer syncing the file verbatim from HA core
 rather than editing by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ The only intentional differences from HA core's `tesla_fleet` are:
 1. **`switch.py`** — the two extra switch descriptions
    (`vehicle_state_low_power_mode`, `vehicle_state_keep_accessory_power_on`)
    plus a `signing_required` field that gates them (in `async_setup_entry`) to
-   vehicles that require command signing. The commands are sent with the
+   vehicles that are command-signing capable (see #6). The commands are sent with the
    **public** `tesla-fleet-api` methods `set_low_power_mode(on)` and
    `set_keep_accessory_power_mode(on)` — do **not** reach into private
    internals (e.g. `api._command`) or hand-build protobuf. They are normal
@@ -51,10 +51,13 @@ The only intentional differences from HA core's `tesla_fleet` are:
    base64 `vehicle_data` protobuf: `charge_state` field 191 = low power,
    field 194 = keep accessory power (both undocumented in Tesla's proto, so
    decoded from raw wire format). The upstream sync leaves it untouched.
-6. **`__init__.py`** — a single `LOGGER.debug` line after the `command_signing`
-   check that logs the raw per-vehicle value, so a user whose power-mode
-   switches are missing can diagnose why (the switches only appear when
-   `command_signing == "required"`). Re-applied by `patch_init` in
+6. **`__init__.py`** — widens the `signing` check to
+   `command_signing in ("required", "allowed")` (core only checks `"required"`),
+   so the switches also appear on `"allowed"` vehicles like the 2025 Model 3
+   (issue #19) — both values mean the vehicle supports the Vehicle Command
+   Protocol. Plus a single `LOGGER.debug` line after the check that logs the raw
+   per-vehicle value, so a user whose power-mode switches are still missing can
+   diagnose why (issue #17). Both re-applied by `patch_init` in
    `apply_patches.py`.
 7. **`README.md` / `hacs.json`** — repo packaging, not part of core.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a custom component that extends the built-in Home Assistant Tesla Fleet 
 
 ## Notes
 
-- These commands use the **Vehicle Command Protocol** (signed protobuf). They will not work on older vehicles that don't support signed commands, so the switches only appear on vehicles that require command signing.
+- These commands use the **Vehicle Command Protocol** (signed protobuf). They will not work on older vehicles that don't support signed commands, so the switches only appear on vehicles that are command-signing capable — Tesla reports `command_signing` as `required` or `allowed` (both supported); `not_required` vehicles don't get the switches.
 - The switches show **real** on/off state, read from the vehicle's `vehicle_data` protobuf snapshot. State reflects changes made anywhere — the Tesla app, an automation, or Home Assistant — within a poll (there's a ~30–50s lag before the Fleet API reflects a change).
 
 ## Releasing a new version

--- a/custom_components/tesla_fleet/__init__.py
+++ b/custom_components/tesla_fleet/__init__.py
@@ -165,11 +165,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             # Remove the protobuff 'cached_data' that we do not use to save memory
             product.pop("cached_data", None)
             vin = product["vin"]
-            signing = product["command_signing"] == "required"
-            # Fork-only diagnostic (issue #17): the low power / keep accessory
-            # power switches are only offered when Tesla reports command signing
-            # is required. Log the raw value so a user whose switches are missing
-            # can confirm what Tesla returns for their VIN.
+            signing = product["command_signing"] in ("required", "allowed")
+            # Fork-only diagnostic (issues #17 / #19): the low power / keep
+            # accessory power switches are only offered when the vehicle is
+            # command-signing capable. Tesla returns "required", "allowed", or
+            # "not_required"; both "required" and "allowed" mean the vehicle
+            # supports the Vehicle Command Protocol, so treat both as signing
+            # (core only checks "required", which hides the switches on
+            # "allowed" vehicles such as the 2025 Model 3). Log the raw value so
+            # a user whose switches are missing can confirm what Tesla returns
+            # for their VIN.
             LOGGER.debug(
                 "Vehicle %s command_signing=%r -> power-mode switches %s",
                 vin,

--- a/custom_components/tesla_fleet/__init__.py
+++ b/custom_components/tesla_fleet/__init__.py
@@ -166,6 +166,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             product.pop("cached_data", None)
             vin = product["vin"]
             signing = product["command_signing"] == "required"
+            # Fork-only diagnostic (issue #17): the low power / keep accessory
+            # power switches are only offered when Tesla reports command signing
+            # is required. Log the raw value so a user whose switches are missing
+            # can confirm what Tesla returns for their VIN.
+            LOGGER.debug(
+                "Vehicle %s command_signing=%r -> power-mode switches %s",
+                vin,
+                product.get("command_signing"),
+                "offered" if signing else "hidden",
+            )
             api_vehicle: VehicleFleet
             if signing:
                 if not tesla.private_key:

--- a/custom_components/tesla_fleet/manifest.json
+++ b/custom_components/tesla_fleet/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "tesla-fleet-api==1.7.2"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/tests/test_apply_patches.py
+++ b/tests/test_apply_patches.py
@@ -243,6 +243,49 @@ def test_coordinator_patch_adds_power_mode_reading(tmp_path, monkeypatch) -> Non
     assert (comp / "coordinator.py").read_text() == result
 
 
+CORE_INIT = (
+    "def async_setup_entry(hass, entry, products, scopes):\n"
+    "    for product in products:\n"
+    '        if "vin" in product and Scope.VEHICLE_DEVICE_DATA in scopes:\n'
+    '            vin = product["vin"]\n'
+    '            signing = product["command_signing"] == "required"\n'
+    "            api_vehicle = None\n"
+)
+
+
+def test_init_patch_adds_command_signing_log(tmp_path, monkeypatch) -> None:
+    comp = tmp_path / "tesla_fleet"
+    comp.mkdir()
+    (comp / "__init__.py").write_text(CORE_INIT)
+    monkeypatch.setattr(ap, "COMPONENT_DIR", comp)
+
+    ap.patch_init()
+    result = (comp / "__init__.py").read_text()
+
+    assert "LOGGER.debug(" in result
+    assert "command_signing=%r" in result
+    assert '"offered" if signing else "hidden"' in result
+    # The signing check and the log line must both be present and in order.
+    assert result.index('signing = product["command_signing"]') < result.index(
+        "LOGGER.debug("
+    )
+    compile(result, "__init__.py", "exec")
+
+    # Re-running is a no-op.
+    ap.patch_init()
+    assert (comp / "__init__.py").read_text() == result
+
+
+def test_init_patch_fails_loudly_on_missing_anchor(tmp_path, monkeypatch) -> None:
+    comp = tmp_path / "tesla_fleet"
+    comp.mkdir()
+    (comp / "__init__.py").write_text("# an upstream file with no known anchors\n")
+    monkeypatch.setattr(ap, "COMPONENT_DIR", comp)
+
+    with pytest.raises(ap.PatchError):
+        ap.patch_init()
+
+
 def test_switch_patch_fails_loudly_on_missing_anchor(tmp_path, monkeypatch) -> None:
     comp = tmp_path / "tesla_fleet"
     comp.mkdir()

--- a/tests/test_apply_patches.py
+++ b/tests/test_apply_patches.py
@@ -265,6 +265,9 @@ def test_init_patch_adds_command_signing_log(tmp_path, monkeypatch) -> None:
     assert "LOGGER.debug(" in result
     assert "command_signing=%r" in result
     assert '"offered" if signing else "hidden"' in result
+    # The signing check is widened to also treat "allowed" as signing-capable.
+    assert 'signing = product["command_signing"] in ("required", "allowed")' in result
+    assert '== "required"' not in result
     # The signing check and the log line must both be present and in order.
     assert result.index('signing = product["command_signing"]') < result.index(
         "LOGGER.debug("

--- a/tests/test_customizations.py
+++ b/tests/test_customizations.py
@@ -54,6 +54,15 @@ def test_switch_source_uses_public_power_mode_api() -> None:
     assert "protobuf" not in src
 
 
+def test_init_logs_per_vehicle_command_signing() -> None:
+    # Fork-only diagnostic (issue #17): the raw command_signing value is logged
+    # at debug so a user whose power-mode switches are missing can see what
+    # Tesla returned for their VIN. Must survive an upstream sync.
+    src = (COMPONENT / "__init__.py").read_text()
+    assert "command_signing=%r" in src
+    assert "LOGGER.debug(" in src
+
+
 def test_strings_have_custom_switch_names() -> None:
     switch = _load_json("strings.json")["entity"]["switch"]
     for key, name in CUSTOM_SWITCH_NAMES.items():

--- a/tests/test_customizations.py
+++ b/tests/test_customizations.py
@@ -63,6 +63,17 @@ def test_init_logs_per_vehicle_command_signing() -> None:
     assert "LOGGER.debug(" in src
 
 
+def test_init_treats_allowed_command_signing_as_signing() -> None:
+    # Issue #19: Tesla returns command_signing="allowed" (e.g. 2025 Model 3) in
+    # addition to "required"/"not_required". Both "required" and "allowed" mean
+    # the vehicle supports the Vehicle Command Protocol, so the signed-only
+    # power-mode switches must be offered for both. Must survive an upstream sync
+    # (core only checks == "required").
+    src = (COMPONENT / "__init__.py").read_text()
+    assert 'product["command_signing"] in ("required", "allowed")' in src
+    assert 'product["command_signing"] == "required"' not in src
+
+
 def test_strings_have_custom_switch_names() -> None:
     switch = _load_json("strings.json")["entity"]["switch"]
     for key, name in CUSTOM_SWITCH_NAMES.items():


### PR DESCRIPTION
## What's in 1.0.4

Two fork changes, both about vehicles whose power-mode switches never appeared:

1. **Log per-vehicle `command_signing` at debug (#17)** — a `LOGGER.debug` line after the signing check logs the raw value Tesla returns per VIN, so a user with missing switches can diagnose why.
2. **Treat `command_signing="allowed"` as signing-capable (#19)** — Tesla returns a third value, `"allowed"` (e.g. the 2025 Model 3), alongside `"required"`/`"not_required"`. Both `required` and `allowed` mean the vehicle supports the Vehicle Command Protocol, so the Low Power / Keep Accessory Power switches now appear on `allowed` vehicles too. Thanks to @hugo-leij for finding this via the `#17` debug log.

## Sync-safe

Because this is a sync-from-upstream fork, the `"allowed"` change lands in four places so it survives a re-sync:

- `custom_components/tesla_fleet/__init__.py` — the widened `signing` check
- `.github/scripts/apply_patches.py` — the sync patch now rewrites the signing line (not just appends the debug log)
- `tests/` — assertions in `test_customizations.py` (real source) and `test_apply_patches.py` (patch output) that both use the widened check
- `AGENTS.md` / `README.md` — docs corrected

## Note

`signing` also selects `createSigned()` vs `createFleet()` for all commands, so `allowed` vehicles now use the signed transport (needs the virtual key paired). Tested working on a 2025 Model 3.

## Verification

- `pytest` → 44 passed
- `ruff` clean on all changed files
- `manifest.json` version = `1.0.4`

Closes #17, closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)