### PR TITLE
Keep power-mode switches optimistic so a cached read can't revert them (v1.0.5)

### DIFF
--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -179,6 +179,51 @@ SWITCH_SETUP_FILTER = """\
                 if vehicle.signing or not description.signing_required
 """
 
+# Route the signed-only switches through the optimistic subclass so a
+# just-issued command isn't reverted by a cached/offline read.
+SWITCH_SETUP_CLASS_OLD = (
+    "                TeslaFleetVehicleSwitchEntity(\n"
+    "                    vehicle, description, entry.runtime_data.scopes\n"
+    "                )\n"
+)
+SWITCH_SETUP_CLASS_NEW = (
+    "                (\n"
+    "                    TeslaFleetPowerModeSwitchEntity\n"
+    "                    if description.signing_required\n"
+    "                    else TeslaFleetVehicleSwitchEntity\n"
+    "                )(vehicle, description, entry.runtime_data.scopes)\n"
+)
+
+# Subclass inserted ahead of the first energy switch class. Its real state
+# comes from the lagging/cached vehicle_data protobuf, so it persists the
+# optimistic value on the coordinator after a successful command.
+SWITCH_POWER_MODE_ENTITY = '''\
+class TeslaFleetPowerModeSwitchEntity(TeslaFleetVehicleSwitchEntity):
+    """Signed low-power / keep-accessory-power switch.
+
+    Its real state comes from the vehicle_data snapshot, which lags and is
+    cached while the car sleeps. After a successful command, record the
+    optimistic value on the coordinator so a later cached/offline read can't
+    revert a command the user just issued until a fresh capture confirms it.
+    """
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on and record the optimistic power-mode state."""
+        await super().async_turn_on(**kwargs)
+        self.coordinator.mark_power_mode(self.key, True)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off and record the optimistic power-mode state."""
+        await super().async_turn_off(**kwargs)
+        self.coordinator.mark_power_mode(self.key, False)
+
+
+'''
+
+SWITCH_ENERGY_CLASS_ANCHOR = "class TeslaFleetChargeFromGridSwitchEntity(\n"
+
 
 def _replace_once(text: str, old: str, new: str, what: str) -> str:
     """Replace ``old`` with ``new`` exactly once or raise PatchError."""
@@ -223,6 +268,19 @@ def patch_switch() -> None:
         "                for description in VEHICLE_DESCRIPTIONS\n",
         SWITCH_SETUP_FILTER,
         "async_setup_entry signing filter",
+    )
+
+    # 4. Route the signed-only switches through the optimistic subclass
+    text = _replace_once(
+        text, SWITCH_SETUP_CLASS_OLD, SWITCH_SETUP_CLASS_NEW, "power-mode entity class"
+    )
+
+    # 5. Insert the optimistic power-mode switch subclass
+    text = _replace_once(
+        text,
+        SWITCH_ENERGY_CLASS_ANCHOR,
+        SWITCH_POWER_MODE_ENTITY + SWITCH_ENERGY_CLASS_ANCHOR,
+        "power-mode switch subclass",
     )
 
     path.write_text(text)
@@ -344,6 +402,25 @@ COORD_RETURN_NEW = """\
         return result
 """
 
+# The optimistic-command persistence method, appended to the vehicle
+# coordinator (right after its _async_update_data return).
+COORD_MARK_OLD = "        result.update(self.power_modes.update(vehicle_data_pb, timestamp))\n        return result\n"
+COORD_MARK_NEW = COORD_MARK_OLD + '''
+    def mark_power_mode(self, key: str, value: bool) -> None:
+        """Record an optimistic power-mode value from a just-issued command.
+
+        The switch toggles optimistically, but its real state comes from the
+        vehicle_data protobuf, which lags and is cached while the car sleeps.
+        Persist the value into both the coordinator data (so the next
+        offline/asleep refresh, which returns ``self.data`` verbatim, keeps it)
+        and the tracker (so a cached read can't revert it until a fresh capture
+        at/after the command confirms real state).
+        """
+        self.power_modes.set_optimistic({key: value}, int(time() * 1000))
+        if self.data is not None:
+            self.data[key] = value
+'''
+
 
 def patch_coordinator() -> None:
     """Read low power / keep accessory power from the vehicle_data protobuf.
@@ -363,6 +440,9 @@ def patch_coordinator() -> None:
     )
     text = _replace_once(
         text, COORD_RETURN_OLD, COORD_RETURN_NEW, "power-mode decode"
+    )
+    text = _replace_once(
+        text, COORD_MARK_OLD, COORD_MARK_NEW, "mark_power_mode method"
     )
     path.write_text(text)
     print("coordinator.py: re-applied power-mode reading")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,11 @@ The only intentional differences from HA core's `tesla_fleet` are:
    **public** `tesla-fleet-api` methods `set_low_power_mode(on)` and
    `set_keep_accessory_power_mode(on)` — do **not** reach into private
    internals (e.g. `api._command`) or hand-build protobuf. They are normal
-   toggles (real state comes from `power_mode.py`), not assumed-state.
+   toggles (real state comes from `power_mode.py`), not assumed-state. These two
+   are built as a fork-only subclass `TeslaFleetPowerModeSwitchEntity` that,
+   after a successful command, calls `coordinator.mark_power_mode(key, value)`
+   so the optimistic toggle is persisted and a cached/offline read can't revert
+   it (see #4/#5).
 2. **`manifest.json`** — adds a `version` field (required for custom
    components) and floors `tesla-fleet-api` to **>= 1.7.2** (the power-mode
    methods need it; older HA releases pin lower, e.g. 2026.7.2 pins 1.4.7). The
@@ -46,11 +50,18 @@ The only intentional differences from HA core's `tesla_fleet` are:
    switches (`icons.json` is synced verbatim; the switches use default icons).
 4. **`coordinator.py`** — requests the `vehicle_data_combo` endpoint and merges
    the decoded low-power / keep-accessory-power state (from `power_mode.py`)
-   into the coordinator data, so the two switches show **real** state.
+   into the coordinator data, so the two switches show **real** state. Also adds
+   `mark_power_mode(key, value)`, which the switch calls after a command to
+   persist the optimistic value into both `self.data` (so the offline
+   early-return, which returns `self.data` verbatim, keeps it) and the tracker.
 5. **`power_mode.py`** — fork-only module (no core equivalent). Decodes the
    base64 `vehicle_data` protobuf: `charge_state` field 191 = low power,
    field 194 = keep accessory power (both undocumented in Tesla's proto, so
-   decoded from raw wire format). The upstream sync leaves it untouched.
+   decoded from raw wire format). `PowerModeTracker` only updates from a capture
+   with a newer timestamp (a cached/asleep read carries a stale one) and holds
+   an optimistic value from `set_optimistic` until a capture at/after the
+   command confirms it — so a just-issued toggle isn't reverted by a stale/
+   cached read while the car sleeps. The upstream sync leaves it untouched.
 6. **`__init__.py`** — widens the `signing` check to
    `command_signing in ("required", "allowed")` (core only checks `"required"`),
    so the switches also appear on `"allowed"` vehicles like the 2025 Model 3

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is a custom component that extends the built-in Home Assistant Tesla Fleet 
 
 - These commands use the **Vehicle Command Protocol** (signed protobuf). They will not work on older vehicles that don't support signed commands, so the switches only appear on vehicles that are command-signing capable — Tesla reports `command_signing` as `required` or `allowed` (both supported); `not_required` vehicles don't get the switches.
 - The switches show **real** on/off state, read from the vehicle's `vehicle_data` protobuf snapshot. State reflects changes made anywhere — the Tesla app, an automation, or Home Assistant — within a poll (there's a ~30–50s lag before the Fleet API reflects a change).
+- When **you** toggle a switch, it holds your new value optimistically until a fresh reading confirms it — a cached/asleep read (the Fleet API serves stale `vehicle_data` while the car sleeps) won't revert it back.
 
 ## Releasing a new version
 

--- a/custom_components/tesla_fleet/coordinator.py
+++ b/custom_components/tesla_fleet/coordinator.py
@@ -226,6 +226,20 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         result.update(self.power_modes.update(vehicle_data_pb, timestamp))
         return result
 
+    def mark_power_mode(self, key: str, value: bool) -> None:
+        """Record an optimistic power-mode value from a just-issued command.
+
+        The switch toggles optimistically, but its real state comes from the
+        vehicle_data protobuf, which lags and is cached while the car sleeps.
+        Persist the value into both the coordinator data (so the next
+        offline/asleep refresh, which returns ``self.data`` verbatim, keeps it)
+        and the tracker (so a cached read can't revert it until a fresh capture
+        at/after the command confirms real state).
+        """
+        self.power_modes.set_optimistic({key: value}, int(time() * 1000))
+        if self.data is not None:
+            self.data[key] = value
+
 
 class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching energy site live status from the TeslaFleet API."""

--- a/custom_components/tesla_fleet/manifest.json
+++ b/custom_components/tesla_fleet/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "tesla-fleet-api==1.7.2"
   ],
-  "version": "1.0.4"
+  "version": "1.0.5"
 }

--- a/custom_components/tesla_fleet/power_mode.py
+++ b/custom_components/tesla_fleet/power_mode.py
@@ -98,23 +98,51 @@ class PowerModeTracker:
     the switches back to a value the user already changed. This keeps the last
     known-good state and only updates it when a newer capture timestamp arrives,
     so a cached/stale read never overrides real state.
+
+    It also remembers an *optimistic* value from a just-issued command (see
+    ``set_optimistic``): the switch is toggled locally, but the protobuf state
+    lags (and is cached while the car sleeps), so a poll landing before Tesla
+    reflects the command — or an offline/asleep read — must not revert it. The
+    optimistic value is held until a capture whose timestamp is at or after the
+    command arrives.
     """
 
     def __init__(self) -> None:
         self._values: dict[str, bool] = {}
         self._timestamp: int = 0
+        # A capture must reach this timestamp (ms epoch, the time a command was
+        # issued) before it is trusted again; 0 means no command is pending.
+        self._pending_until: int = 0
+
+    def set_optimistic(self, values: dict[str, bool], command_time: int) -> None:
+        """Record state from a just-issued command, trusted until confirmed.
+
+        ``command_time`` is a millisecond epoch (compared against the capture's
+        ``charge_state_timestamp``). Until a capture at or after it arrives, a
+        cached/stale/offline read cannot revert these values.
+        """
+        self._values.update(values)
+        self._pending_until = command_time
 
     def update(self, vehicle_data_b64: str | None, timestamp: int) -> dict[str, bool]:
         """Refresh from a newer capture and return the current state to merge."""
         if vehicle_data_b64 is not None and (
             timestamp == 0 or timestamp > self._timestamp
         ):
+            # While a command is pending, only a capture proven newer than the
+            # command may override it. A cached/asleep read carries a pre-command
+            # (or missing) timestamp, so it must not revert the optimistic value.
+            if self._pending_until and (timestamp == 0 or timestamp < self._pending_until):
+                return dict(self._values)
             decoded = decode_power_modes(vehicle_data_b64)
             if decoded:
                 self._values = decoded
                 # Keep the watermark monotonic so a missing (0) timestamp never
                 # lowers it and lets a later stale read through.
                 self._timestamp = max(self._timestamp, timestamp)
+                # A capture at/after the command confirms (or supersedes) it.
+                if timestamp and timestamp >= self._pending_until:
+                    self._pending_until = 0
         return dict(self._values)
 
 

--- a/custom_components/tesla_fleet/switch.py
+++ b/custom_components/tesla_fleet/switch.py
@@ -116,9 +116,11 @@ async def async_setup_entry(
     async_add_entities(
         chain(
             (
-                TeslaFleetVehicleSwitchEntity(
-                    vehicle, description, entry.runtime_data.scopes
-                )
+                (
+                    TeslaFleetPowerModeSwitchEntity
+                    if description.signing_required
+                    else TeslaFleetVehicleSwitchEntity
+                )(vehicle, description, entry.runtime_data.scopes)
                 for vehicle in entry.runtime_data.vehicles
                 for description in VEHICLE_DESCRIPTIONS
                 # Signed-only commands (low power / keep accessory power) are
@@ -191,6 +193,28 @@ class TeslaFleetVehicleSwitchEntity(TeslaFleetVehicleEntity, TeslaFleetSwitchEnt
         await handle_vehicle_command(self.entity_description.off_func(self.api))
         self._attr_is_on = False
         self.async_write_ha_state()
+
+
+class TeslaFleetPowerModeSwitchEntity(TeslaFleetVehicleSwitchEntity):
+    """Signed low-power / keep-accessory-power switch.
+
+    Its real state comes from the vehicle_data snapshot, which lags and is
+    cached while the car sleeps. After a successful command, record the
+    optimistic value on the coordinator so a later cached/offline read can't
+    revert a command the user just issued until a fresh capture confirms it.
+    """
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on and record the optimistic power-mode state."""
+        await super().async_turn_on(**kwargs)
+        self.coordinator.mark_power_mode(self.key, True)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off and record the optimistic power-mode state."""
+        await super().async_turn_off(**kwargs)
+        self.coordinator.mark_power_mode(self.key, False)
 
 
 class TeslaFleetChargeFromGridSwitchEntity(

--- a/tests/test_apply_patches.py
+++ b/tests/test_apply_patches.py
@@ -188,6 +188,14 @@ def test_switch_patch_reinjects_customizations(tmp_path, monkeypatch) -> None:
     assert "api.set_keep_accessory_power_mode(on=False)" in result
     assert "if vehicle.signing or not description.signing_required" in result
     assert "assumed_state" not in result
+    # The optimistic power-mode subclass and its routing must be re-injected.
+    assert (
+        "class TeslaFleetPowerModeSwitchEntity(TeslaFleetVehicleSwitchEntity)" in result
+    )
+    assert "self.coordinator.mark_power_mode(self.key, True)" in result
+    assert "self.coordinator.mark_power_mode(self.key, False)" in result
+    assert "TeslaFleetPowerModeSwitchEntity\n" in result
+    assert "if description.signing_required\n" in result
     # The result must be valid Python.
     compile(result, "switch.py", "exec")
 
@@ -237,6 +245,10 @@ def test_coordinator_patch_adds_power_mode_reading(tmp_path, monkeypatch) -> Non
     assert 'data.pop("vehicle_data", None)' in result
     assert 'timestamp = result.get("charge_state_timestamp")' in result
     assert "self.power_modes.update(vehicle_data_pb, timestamp)" in result
+    # The optimistic-command persistence method must be re-injected.
+    assert "def mark_power_mode(self, key: str, value: bool)" in result
+    assert "self.power_modes.set_optimistic({key: value}, int(time() * 1000))" in result
+    compile(result, "coordinator.py", "exec")
 
     # Re-running is a no-op.
     ap.patch_coordinator()

--- a/tests/test_customizations.py
+++ b/tests/test_customizations.py
@@ -54,6 +54,33 @@ def test_switch_source_uses_public_power_mode_api() -> None:
     assert "protobuf" not in src
 
 
+def test_switch_persists_optimistic_power_mode_state() -> None:
+    # The stale-state fix: the two power-mode switches must be the optimistic
+    # subclass that records the command on the coordinator, so a cached/offline
+    # read can't revert a just-issued toggle. Must survive an upstream sync.
+    src = (COMPONENT / "switch.py").read_text()
+    assert "class TeslaFleetPowerModeSwitchEntity" in src
+    assert "self.coordinator.mark_power_mode(self.key, True)" in src
+    assert "self.coordinator.mark_power_mode(self.key, False)" in src
+    assert "if description.signing_required" in src
+
+
+def test_coordinator_marks_optimistic_power_mode() -> None:
+    # Counterpart to the switch: the coordinator persists the optimistic value
+    # into both the tracker and self.data so the offline early-return keeps it.
+    src = (COMPONENT / "coordinator.py").read_text()
+    assert "def mark_power_mode(self, key: str, value: bool)" in src
+    assert "set_optimistic(" in src
+
+
+def test_power_mode_tracker_holds_pending_command() -> None:
+    # The tracker must implement the optimistic/pending guard that keeps a
+    # just-issued command until a fresh capture confirms it.
+    src = (COMPONENT / "power_mode.py").read_text()
+    assert "def set_optimistic(" in src
+    assert "_pending_until" in src
+
+
 def test_init_logs_per_vehicle_command_signing() -> None:
     # Fork-only diagnostic (issue #17): the raw command_signing value is logged
     # at debug so a user whose power-mode switches are missing can see what

--- a/tests/test_power_mode.py
+++ b/tests/test_power_mode.py
@@ -161,6 +161,52 @@ def test_tracker_zero_timestamp_keeps_watermark() -> None:
     assert tracker.update(_make(low=0), 150) == {"vehicle_state_low_power_mode": True}
 
 
+def test_optimistic_survives_cached_read() -> None:
+    # The reported bug: user turns the switch off; the car then sleeps and the
+    # Fleet API returns a cached charge_state (older/equal timestamp) still
+    # showing "on". The optimistic off must NOT be reverted.
+    tracker = pm.PowerModeTracker()
+    tracker.update(_make(keep=1), 1000)  # last real state: keep = on
+
+    tracker.set_optimistic({"vehicle_state_keep_accessory_power_on": False}, 2000)
+    # Cached/asleep read with a pre-command (or equal) timestamp is ignored.
+    assert tracker.update(_make(keep=1), 1000) == {
+        "vehicle_state_keep_accessory_power_on": False
+    }
+    assert tracker.update(_make(keep=1), 1500) == {
+        "vehicle_state_keep_accessory_power_on": False
+    }
+    # A missing-timestamp read during a pending command is also ignored.
+    assert tracker.update(_make(keep=1), 0) == {
+        "vehicle_state_keep_accessory_power_on": False
+    }
+
+
+def test_optimistic_cleared_by_fresh_capture() -> None:
+    # A capture at/after the command confirms real state and ends the pending
+    # window, so subsequent genuine changes are trusted again.
+    tracker = pm.PowerModeTracker()
+    tracker.set_optimistic({"vehicle_state_low_power_mode": False}, 2000)
+    # Fresh capture (ts >= command) is trusted — here it confirms the off.
+    assert tracker.update(_make(low=0), 2500) == {
+        "vehicle_state_low_power_mode": False
+    }
+    # Pending is cleared: a later real on is now honoured immediately.
+    assert tracker.update(_make(low=1), 2600) == {
+        "vehicle_state_low_power_mode": True
+    }
+
+
+def test_optimistic_overridden_when_car_changes_it_back() -> None:
+    # If the owner flips it back in the app, the next fresh capture (newer than
+    # the command) must win over the optimistic value.
+    tracker = pm.PowerModeTracker()
+    tracker.set_optimistic({"vehicle_state_low_power_mode": False}, 2000)
+    assert tracker.update(_make(low=1), 3000) == {
+        "vehicle_state_low_power_mode": True
+    }
+
+
 def test_coordinator_merge_contract() -> None:
     # Mirrors what coordinator._async_update_data does: pop the protobuf, decode
     # it, and merge the booleans into the (flattened) result dict.

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -84,6 +84,91 @@ def test_library_methods_accept_on_kwarg(method: str) -> None:
     assert list(params) == ["self", "on"]
 
 
+def test_power_mode_switches_use_optimistic_subclass() -> None:
+    # The two signed power-mode switches must be the optimistic subclass so a
+    # cached/offline read can't revert a just-issued command; the other
+    # (JSON-backed) switches stay on the base class.
+    assert issubclass(
+        switch.TeslaFleetPowerModeSwitchEntity, switch.TeslaFleetVehicleSwitchEntity
+    )
+    cls_for = {
+        d.key: (
+            switch.TeslaFleetPowerModeSwitchEntity
+            if d.signing_required
+            else switch.TeslaFleetVehicleSwitchEntity
+        )
+        for d in switch.VEHICLE_DESCRIPTIONS
+    }
+    for key in CUSTOM_SWITCHES:
+        assert cls_for[key] is switch.TeslaFleetPowerModeSwitchEntity
+    assert cls_for["vehicle_state_sentry_mode"] is switch.TeslaFleetVehicleSwitchEntity
+
+
+@pytest.mark.parametrize("key", CUSTOM_SWITCHES)
+@pytest.mark.parametrize("turn_on", [True, False])
+async def test_power_mode_switch_marks_optimistic_state(
+    key: str, turn_on: bool
+) -> None:
+    # After a successful command the switch must persist the optimistic value on
+    # the coordinator (both the tracker and the data), or the next offline poll
+    # reverts it — the reported stale-state bug.
+    from types import SimpleNamespace
+
+    marks: list[tuple[str, bool]] = []
+    coordinator = SimpleNamespace(
+        data={key: not turn_on},
+        mark_power_mode=lambda k, v: marks.append((k, v)),
+    )
+
+    entity = switch.TeslaFleetPowerModeSwitchEntity.__new__(
+        switch.TeslaFleetPowerModeSwitchEntity
+    )
+    entity.entity_description = _description(key)
+    entity.key = key
+    entity.coordinator = coordinator
+    entity.scoped = True
+    entity.api = _FakeSignedApi()
+    entity.raise_for_read_only = lambda scope: None
+    entity.wake_up_if_asleep = _noop
+    entity.async_write_ha_state = lambda: None
+
+    if turn_on:
+        await entity.async_turn_on()
+    else:
+        await entity.async_turn_off()
+
+    assert entity._attr_is_on is turn_on
+    assert marks == [(key, turn_on)]
+
+
+async def _noop(*args, **kwargs) -> None:
+    return None
+
+
+def test_coordinator_mark_power_mode_persists_both_places() -> None:
+    # End-to-end contract for the stale-state fix: mark_power_mode must update
+    # self.data (so the offline early-return, which returns self.data verbatim,
+    # keeps the value) AND the tracker (so a cached read can't revert it).
+    from custom_components.tesla_fleet import coordinator as coord
+    from custom_components.tesla_fleet.power_mode import PowerModeTracker
+
+    key = "vehicle_state_keep_accessory_power_on"
+    c = coord.TeslaFleetVehicleDataCoordinator.__new__(
+        coord.TeslaFleetVehicleDataCoordinator
+    )
+    c.power_modes = PowerModeTracker()
+    c.data = {key: True}  # last known real state: on
+
+    c.mark_power_mode(key, False)
+
+    # self.data reflects the optimistic off (offline refresh returns this).
+    assert c.data[key] is False
+    # A stale/cached read (old timestamp) via the tracker cannot revert it.
+    from tests.test_power_mode import _make
+
+    assert c.power_modes.update(_make(keep=1), 1) == {key: False}
+
+
 @pytest.mark.parametrize("key", CUSTOM_SWITCHES)
 def test_switch_reflects_decoded_coordinator_state(key: str) -> None:
     # The coordinator merges the decoded protobuf booleans under the switch


### PR DESCRIPTION
## Symptom

Turning **Keep accessory power** (or **Low power mode**) *off* — command confirmed applied on the vehicle — could flip back to **on** ~1 poll cycle later, on its own, after the car went to sleep. HA then showed `on` while the vehicle's accessory power was actually `off`. Diagnosed from a real HA instance (2025 Model 3, HA 2026.7.1).

## Root cause

The switch toggles **optimistically** — `async_turn_off` sets only the entity's `_attr_is_on` and writes state; it never touches the coordinator. When the car sleeps, `coordinator._async_update_data` early-returns `self.data` **verbatim** (still holding the pre-toggle value), and `_handle_coordinator_update → _async_update_attrs` re-reads it, reverting the switch.

The v1.0.3 freshness gate only guarded against a *fresh protobuf blob with a stale timestamp* overriding state via `PowerModeTracker.update`. It did nothing about the un-persisted optimistic write, which is the actual revert path.

## Fix

The two signed power-mode switches are now a fork-only subclass **`TeslaFleetPowerModeSwitchEntity`** that, after a successful command, calls **`coordinator.mark_power_mode(key, value)`**. That persists the value into:

- **`self.data`** — so the offline/asleep early-return (which returns `self.data` verbatim) keeps it, and
- **`PowerModeTracker`** (`set_optimistic`) — which holds the optimistic value until a capture whose timestamp is **at/after the command** confirms real state.

This covers **both** the offline revert (the reported case) **and** the wake/poll-lag revert (a poll landing inside the ~30–50s Fleet-API propagation window). If the owner flips it back in the Tesla app, the next genuinely fresh capture still wins.

## Sync-safe

- `switch.py` — subclass + class routing (via `signing_required`) re-applied by `apply_patches.py` (patch steps 4 & 5).
- `coordinator.py` — `mark_power_mode` re-applied by the coordinator patch.
- `power_mode.py` — fork-only, untouched by sync.
- Running the patcher on the shipped tree is a clean no-op (idempotent).

## Tests

+12 tests (44 → 56): tracker optimistic/pending guard, switch routing + `mark_power_mode` call, coordinator persists-both-places contract, and patch-reinjection assertions. `pytest` 56 passed; `ruff check tests .github/scripts` clean.

## Not included (separate follow-ups noted in the diagnostic)

- Command-signing session going stale (`Command signature/MAC is incorrect …`) → needs a re-handshake + retry (lives in `tesla-fleet-api`).
- A `_async_update_attrs` crash on partial/offline data (`select.py`) → harden against missing keys.

Bumps version to **1.0.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)