### PR TITLE
Track tesla-fleet-api pin across syncs; assert the floor not an exact version

### DIFF
--- a/.github/scripts/apply_patches.py
+++ b/.github/scripts/apply_patches.py
@@ -5,7 +5,10 @@ The upstream sync workflow downloads ``custom_components/tesla_fleet`` verbatim
 from ``home-assistant/core``. This script then re-adds the small set of changes
 that make this a custom component:
 
-* ``manifest.json`` — the ``version`` field custom components require.
+* ``manifest.json`` — the ``version`` field custom components require, and a
+  floor on the ``tesla-fleet-api`` pin (>= the power-mode minimum).
+* ``requirements_test.txt`` — the CI test env's ``tesla-fleet-api`` pin is kept
+  aligned with the (floored) manifest pin so tests exercise what ships.
 * ``switch.py`` — the two extra vehicle switches (low power mode / keep
   accessory power) sent via the public ``tesla-fleet-api`` power-mode methods.
 * ``__init__.py`` — treat ``command_signing == "allowed"`` as signing-capable
@@ -33,6 +36,7 @@ import urllib.request
 from pathlib import Path
 
 COMPONENT_DIR = Path("custom_components/tesla_fleet")
+REQUIREMENTS_TEST = Path("requirements_test.txt")
 UPSTREAM_REF = os.environ.get("UPSTREAM_REF", "2026.7.2")
 RAW_BASE = (
     f"https://raw.githubusercontent.com/home-assistant/core/{UPSTREAM_REF}/homeassistant"
@@ -145,6 +149,40 @@ def patch_manifest() -> None:
     ordered.update({k: manifest[k] for k in sorted(manifest)})
     path.write_text(json.dumps(ordered, indent=2) + "\n")
     print(f"manifest.json: applied fork fields (version {ordered.get('version')})")
+
+
+def _manifest_tesla_fleet_api_pin() -> str | None:
+    """Return the tesla-fleet-api ``==`` requirement from the manifest, or None."""
+    manifest = json.loads((COMPONENT_DIR / "manifest.json").read_text())
+    for req in manifest.get("requirements", []):
+        if req.startswith("tesla-fleet-api=="):
+            return req
+    return None
+
+
+def patch_requirements_test() -> None:
+    """Keep the test env's tesla-fleet-api pin aligned with the manifest.
+
+    The manifest pin is floored to the power-mode minimum and otherwise follows
+    core's bumps; the CI test environment should install the same version so it
+    exercises what ships. Run after ``patch_manifest`` and touch only the
+    tesla-fleet-api line (homeassistant / pytest / ruff pins are left alone).
+    """
+    pin = _manifest_tesla_fleet_api_pin()
+    if pin is None or not REQUIREMENTS_TEST.exists():
+        return
+    lines = REQUIREMENTS_TEST.read_text().splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.strip().startswith("tesla-fleet-api=="):
+            updated = pin + ("\n" if line.endswith("\n") else "")
+            if line == updated:
+                print("requirements_test.txt: tesla-fleet-api pin already aligned")
+                return
+            lines[i] = updated
+            REQUIREMENTS_TEST.write_text("".join(lines))
+            print(f"requirements_test.txt: aligned tesla-fleet-api pin to {pin}")
+            return
+    print("requirements_test.txt: no tesla-fleet-api pin to align")
 
 
 # ---------------------------------------------------------------------------
@@ -553,6 +591,7 @@ def main() -> None:
         print(f"ERROR: {COMPONENT_DIR} does not exist", file=sys.stderr)
         sys.exit(1)
     patch_manifest()
+    patch_requirements_test()
     patch_switch()
     patch_init()
     patch_coordinator()

--- a/tests/test_apply_patches.py
+++ b/tests/test_apply_patches.py
@@ -114,6 +114,35 @@ def test_manifest_patch_adds_default_version_and_is_idempotent(
     assert (comp / "manifest.json").read_text() == once
 
 
+def test_requirements_test_pin_follows_manifest(tmp_path, monkeypatch) -> None:
+    # The CI test env's tesla-fleet-api pin must track the (floored) manifest pin
+    # so a core bump (e.g. 1.7.2 -> 1.7.6) updates both together — otherwise a
+    # sync PR ships a manifest requiring a version the tests never exercise.
+    comp = tmp_path / "tesla_fleet"
+    comp.mkdir()
+    (comp / "manifest.json").write_text(
+        json.dumps({"domain": "tesla_fleet", "requirements": ["tesla-fleet-api==1.7.6"]})
+    )
+    req = tmp_path / "requirements_test.txt"
+    req.write_text(
+        "homeassistant==2026.7.2\ntesla-fleet-api==1.7.2\npytest==9.1.1\n"
+    )
+    monkeypatch.setattr(ap, "COMPONENT_DIR", comp)
+    monkeypatch.setattr(ap, "REQUIREMENTS_TEST", req)
+
+    ap.patch_requirements_test()
+    lines = req.read_text().splitlines()
+    assert "tesla-fleet-api==1.7.6" in lines
+    # Other pins are left untouched.
+    assert "homeassistant==2026.7.2" in lines
+    assert "pytest==9.1.1" in lines
+
+    # Re-running is a no-op.
+    once = req.read_text()
+    ap.patch_requirements_test()
+    assert req.read_text() == once
+
+
 def test_manifest_patch_preserves_committed_version(tmp_path, monkeypatch) -> None:
     # A sync must not reset a released version back to the default.
     comp = tmp_path / "tesla_fleet"

--- a/tests/test_customizations.py
+++ b/tests/test_customizations.py
@@ -30,9 +30,16 @@ def _load_json(name: str) -> dict:
 
 def test_manifest_pins_dependency_with_power_mode_methods() -> None:
     manifest = _load_json("manifest.json")
-    # 1.7.2 is the first release exposing set_low_power_mode /
-    # set_keep_accessory_power_mode and the version HA core pins.
-    assert manifest["requirements"] == ["tesla-fleet-api==1.7.2"]
+    # The power-mode commands (set_low_power_mode / set_keep_accessory_power_mode)
+    # need tesla-fleet-api >= 1.7.2. apply_patches floors the pin to that but
+    # never downgrades a newer core pin, so assert the floor rather than an exact
+    # value (core has since moved past 1.7.2, e.g. 1.7.6).
+    pins = [
+        r for r in manifest["requirements"] if r.startswith("tesla-fleet-api==")
+    ]
+    assert len(pins) == 1, manifest["requirements"]
+    version = tuple(int(p) for p in pins[0].split("==", 1)[1].split("."))
+    assert version >= (1, 7, 2), pins[0]
 
 
 def test_manifest_has_custom_component_version() -> None:


### PR DESCRIPTION
Follow-up to the failed [sync run](https://github.com/jeffborg/tesla-fleet-extra/actions/runs/31076247276/job/92534820039).

## Context

The sync of newer HA core succeeded (patches applied, branch `sync/ha-core-4a9dce1` pushed) but the workflow's **last** step failed: *"GitHub Actions is not permitted to create or approve pull requests."* That's a repo **Actions setting** (Settings → Actions → General → Workflow permissions → *Allow GitHub Actions to create and approve pull requests*), not a code bug — this PR does **not** change that.

What this PR fixes is a latent problem the sync surfaced: core bumped its `tesla-fleet-api` pin **1.7.2 → 1.7.6**, and two things assumed 1.7.2 forever.

## Changes

1. **`test_manifest_pins_dependency_with_power_mode_methods`** hard-asserted `== "1.7.2"`, contradicting the documented floor (`>= 1.7.2`, never downgrade a newer core pin). It would fail on every sync PR carrying a core bump. Now asserts the floor.
2. **`requirements_test.txt`** pinned `tesla-fleet-api` independently, so a manifest bump left CI testing an older version than ships. `apply_patches.py` now aligns the test-env pin to the (floored) manifest pin as a patch step (`patch_requirements_test`), so future core bumps move both together.

On `master` (manifest `1.7.2`) nothing changes — the patcher reports the pin "already aligned"; the bump to `1.7.6` happens on the sync branch where the manifest is `1.7.6` (verified by `test_requirements_test_pin_follows_manifest`).

## Verification

- 56 → 57 tests; full suite passes against **both** tesla-fleet-api 1.7.2 and 1.7.6.
- `ruff check tests .github/scripts` clean.
- `apply_patches.py` is a clean no-op on the shipped tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)